### PR TITLE
New rscript nondefault

### DIFF
--- a/pkg/R/streaming.R
+++ b/pkg/R/streaming.R
@@ -373,6 +373,11 @@ rmr.stream =
                              stream.reduce.input,
                              stream.reduce.output)
 
+    # Non-default rscript settings (MR script)
+    # bp = rmr.options("backend.parameters");
+    # bp$rscript = "/opt/R/R-3.6.3/bin/Rscript --vanilla";
+    # rmr.options(backend.parameters = bp);
+
     bp = rmr.options('backend.parameters')
     rscript = ifelse(
         is.null(bp[['rscript']]), 'Rscript --vanilla', bp[['rscript']])

--- a/pkg/R/streaming.R
+++ b/pkg/R/streaming.R
@@ -372,7 +372,11 @@ rmr.stream =
                              stream.map.output,
                              stream.reduce.input,
                              stream.reduce.output)
-    rscript = 'Rscript --vanilla'
+
+    bp = rmr.options('backend.parameters')
+    rscript = ifelse(
+        is.null(bp[['rscript']]), 'Rscript --vanilla', bp[['rscript']])
+
     mapper = paste.options(
       mapper = 
         paste(


### PR DESCRIPTION
Non-default rscript settings (MR script). See example below

bp = rmr.options("backend.parameters");
bp$rscript = "/opt/R/R-3.6.3/bin/Rscript --vanilla";
 rmr.options(backend.parameters = bp);
